### PR TITLE
Suppress "unused declaration" inspection for certain declarations

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -35,6 +35,7 @@
           displayType="STICKY_BALLOON"
           key="compiler.devkit.run_apply"/>
 
+        <lang.inspectionSuppressor language="kotlin" implementationClass="org.jetbrains.kotlin.test.helper.inspections.UnusedDeclarationSuppressor"/>
     </extensions>
 
     <extensions defaultExtensionNs="org.jetbrains.kotlin">

--- a/src/org/jetbrains/kotlin/test/helper/inspections/UnusedDeclarationSuppressor.kt
+++ b/src/org/jetbrains/kotlin/test/helper/inspections/UnusedDeclarationSuppressor.kt
@@ -1,0 +1,31 @@
+package org.jetbrains.kotlin.test.helper.inspections
+
+import com.intellij.codeInspection.InspectionSuppressor
+import com.intellij.codeInspection.SuppressQuickFix
+import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.idea.base.psi.KotlinPsiHeuristics
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtAnnotated
+
+/**
+ * Suppresses the "unused declaration" inspection for declarations annotated with one of the [entryPoints] annotations.
+ */
+class UnusedDeclarationSuppressor : InspectionSuppressor {
+    override fun isSuppressedFor(element: PsiElement, toolId: String): Boolean =
+        toolId.lowercase() == "unused" &&
+                element is KtAnnotated &&
+                entryPoints.any { KotlinPsiHeuristics.hasAnnotation(element, it) }
+
+    override fun getSuppressActions(element: PsiElement?, toolId: String): Array<out SuppressQuickFix?> =
+        SuppressQuickFix.EMPTY_ARRAY
+}
+
+private val entryPoints: List<FqName> = listOf(
+    // Compiler
+    "org.jetbrains.kotlin.utils.IDEAPluginsCompatibilityAPI",
+
+    // Standard library
+    "kotlin.internal.UsedFromCompilerGeneratedCode",
+    "kotlin.js.JsIntrinsic",
+    "kotlin.wasm.internal.ExcludedFromCodegen",
+).map(::FqName)


### PR DESCRIPTION
Declarations annotated with certain annotations inside the compiler and the standard library are effectively entry points and should not be highlighted as unused.